### PR TITLE
Allow comment replies

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -3,9 +3,9 @@
 --
 
 -- Dumped from database version 14.5 (Debian 14.5-2.pgdg110+2)
--- Dumped by pg_dump version 14.4
+-- Dumped by pg_dump version 15.1
 
--- Started on 2022-11-28 20:55:58
+-- Started on 2023-02-16 22:28:26
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -18,10 +18,18 @@ SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
+--
+-- TOC entry 4 (class 2615 OID 2200)
+-- Name: public; Type: SCHEMA; Schema: -; Owner: -
+--
+
+-- *not* creating schema, since initdb creates it
+
+
 SET default_table_access_method = heap;
 
 --
--- TOC entry 210 (class 1259 OID 24577)
+-- TOC entry 209 (class 1259 OID 16385)
 -- Name: comments; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -32,12 +40,13 @@ CREATE TABLE public.comments (
     created_at timestamp with time zone NOT NULL,
     updated_at timestamp with time zone NOT NULL,
     post_id uuid NOT NULL,
-    user_id uuid NOT NULL
+    user_id uuid NOT NULL,
+    parent_comment_id uuid
 );
 
 
 --
--- TOC entry 209 (class 1259 OID 16385)
+-- TOC entry 210 (class 1259 OID 16390)
 -- Name: posts; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -52,7 +61,7 @@ CREATE TABLE public.posts (
 
 
 --
--- TOC entry 212 (class 1259 OID 24622)
+-- TOC entry 211 (class 1259 OID 16396)
 -- Name: user_credentials; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -63,7 +72,7 @@ CREATE TABLE public.user_credentials (
 
 
 --
--- TOC entry 211 (class 1259 OID 24590)
+-- TOC entry 212 (class 1259 OID 16401)
 -- Name: users; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -75,7 +84,7 @@ CREATE TABLE public.users (
 
 
 --
--- TOC entry 3182 (class 2606 OID 24583)
+-- TOC entry 3180 (class 2606 OID 16407)
 -- Name: comments comments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -84,7 +93,7 @@ ALTER TABLE ONLY public.comments
 
 
 --
--- TOC entry 3180 (class 2606 OID 16392)
+-- TOC entry 3185 (class 2606 OID 16409)
 -- Name: posts posts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -93,7 +102,7 @@ ALTER TABLE ONLY public.posts
 
 
 --
--- TOC entry 3191 (class 2606 OID 24628)
+-- TOC entry 3188 (class 2606 OID 16411)
 -- Name: user_credentials user_credentials_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -102,7 +111,7 @@ ALTER TABLE ONLY public.user_credentials
 
 
 --
--- TOC entry 3186 (class 2606 OID 24636)
+-- TOC entry 3190 (class 2606 OID 16413)
 -- Name: users username_u; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -111,7 +120,7 @@ ALTER TABLE ONLY public.users
 
 
 --
--- TOC entry 3188 (class 2606 OID 24596)
+-- TOC entry 3192 (class 2606 OID 16415)
 -- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -120,7 +129,7 @@ ALTER TABLE ONLY public.users
 
 
 --
--- TOC entry 3189 (class 1259 OID 24634)
+-- TOC entry 3186 (class 1259 OID 16416)
 -- Name: fki_fk_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -128,7 +137,15 @@ CREATE INDEX fki_fk_user_id ON public.user_credentials USING btree (user_id);
 
 
 --
--- TOC entry 3183 (class 1259 OID 24589)
+-- TOC entry 3181 (class 1259 OID 16444)
+-- Name: fki_parent_comment_id_fk; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX fki_parent_comment_id_fk ON public.comments USING btree (parent_comment_id);
+
+
+--
+-- TOC entry 3182 (class 1259 OID 16417)
 -- Name: fki_post_id_fk; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -136,7 +153,7 @@ CREATE INDEX fki_post_id_fk ON public.comments USING btree (post_id);
 
 
 --
--- TOC entry 3184 (class 1259 OID 24616)
+-- TOC entry 3183 (class 1259 OID 16418)
 -- Name: fki_user_id_fk; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -144,7 +161,7 @@ CREATE INDEX fki_user_id_fk ON public.comments USING btree (user_id);
 
 
 --
--- TOC entry 3195 (class 2606 OID 24629)
+-- TOC entry 3197 (class 2606 OID 16419)
 -- Name: user_credentials fk_user_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -153,7 +170,16 @@ ALTER TABLE ONLY public.user_credentials
 
 
 --
--- TOC entry 3194 (class 2606 OID 24637)
+-- TOC entry 3193 (class 2606 OID 16445)
+-- Name: comments parent_comment_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.comments
+    ADD CONSTRAINT parent_comment_id_fk FOREIGN KEY (parent_comment_id) REFERENCES public.comments(id) ON DELETE CASCADE NOT VALID;
+
+
+--
+-- TOC entry 3194 (class 2606 OID 16424)
 -- Name: comments post_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -162,7 +188,7 @@ ALTER TABLE ONLY public.comments
 
 
 --
--- TOC entry 3193 (class 2606 OID 24611)
+-- TOC entry 3195 (class 2606 OID 16429)
 -- Name: comments user_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -171,7 +197,7 @@ ALTER TABLE ONLY public.comments
 
 
 --
--- TOC entry 3192 (class 2606 OID 24617)
+-- TOC entry 3196 (class 2606 OID 16434)
 -- Name: posts user_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -179,7 +205,7 @@ ALTER TABLE ONLY public.posts
     ADD CONSTRAINT user_id_fk FOREIGN KEY (user_id) REFERENCES public.users(id) NOT VALID;
 
 
--- Completed on 2022-11-28 20:55:58
+-- Completed on 2023-02-16 22:28:26
 
 --
 -- PostgreSQL database dump complete

--- a/src/Controllers/Api.hs
+++ b/src/Controllers/Api.hs
@@ -104,6 +104,12 @@ data PostRoutes mode = PostRoutes
       :> CursorParam
       :> PageSizeParam
       :> Http.Get '[JSON] (Page CommentDto)
+  , createPostComment :: mode
+      -- POST /posts/:postId/comments
+      :- Capture "postId" (Id Post)
+      :> "comments"
+      :> ReqBody '[JSON] NewCommentDto
+      :> Http.Post '[JSON] CommentIdDto
   }
   deriving Generic
 
@@ -115,6 +121,7 @@ postHandlers = PostRoutes
   , createPost = PostController.createPost
   , deletePost = PostController.deletePost
   , getPostComments = CommentController.getPostComments
+  , createPostComment = CommentController.createPostComment
   }
 
 data CommentRoutes mode = CommentRoutes
@@ -122,10 +129,6 @@ data CommentRoutes mode = CommentRoutes
       -- GET /comments/:commentId
       :- Capture "comment" (Id Comment)
       :> Http.Get '[JSON] CommentDto
-  , createComment :: mode
-      -- POST /comments
-      :- ReqBody '[JSON] NewCommentDto
-      :> Http.Post '[JSON] CommentIdDto
   , deleteComment :: mode
       -- DELETE /comments/:commentId
       :- Capture "commentId" (Id Comment)
@@ -139,6 +142,12 @@ data CommentRoutes mode = CommentRoutes
       :> CursorParam
       :> PageSizeParam
       :> Http.Get '[JSON] (Page CommentDto)
+  , createCommentReply :: mode
+      -- POST /comments/:commentId/comments
+      :- Capture "commentId" (Id Comment)
+      :> "comments"
+      :> ReqBody '[JSON] NewCommentDto
+      :> Http.Post '[JSON] CommentIdDto
   }
   deriving Generic
 
@@ -146,7 +155,7 @@ commentHandlers :: (?requestCtx :: RequestContext)
   => CommentRoutes (AsServerT App)
 commentHandlers = CommentRoutes
   { getComment = CommentController.getComment
-  , createComment = CommentController.createComment
   , deleteComment = CommentController.deleteComment
   , getCommentReplies = CommentController.getCommentReplies
+  , createCommentReply = CommentController.createCommentReply
   }

--- a/src/Controllers/Api.hs
+++ b/src/Controllers/Api.hs
@@ -95,6 +95,15 @@ data PostRoutes mode = PostRoutes
       -- DELETE /posts/:postId
       :- Capture "postId" (Id Post)
       :> Http.Delete '[JSON] Http.NoContent
+  , getPostComments :: mode
+      -- GET /posts/:postId/comments
+      :- Capture "postId" (Id Post)
+      :> "comments"
+      :> SortByParam Sort
+      :> OrderParam
+      :> CursorParam
+      :> PageSizeParam
+      :> Http.Get '[JSON] (Page CommentDto)
   }
   deriving Generic
 
@@ -105,6 +114,7 @@ postHandlers = PostRoutes
   , getPost = PostController.getPost
   , createPost = PostController.createPost
   , deletePost = PostController.deletePost
+  , getPostComments = CommentController.getPostComments
   }
 
 data CommentRoutes mode = CommentRoutes
@@ -125,9 +135,18 @@ data CommentRoutes mode = CommentRoutes
       :- ReqBody '[JSON] NewCommentDto
       :> Http.Post '[JSON] CommentIdDto
   , deleteComment :: mode
-      -- DELETE /comments/:postId
+      -- DELETE /comments/:commentId
       :- Capture "commentId" (Id Comment)
       :> Http.Delete '[JSON] Http.NoContent
+  , getCommentComments :: mode
+      -- GET /comments/:commentId/comments
+      :- Capture "commentId" (Id Comment)
+      :> "comments"
+      :> SortByParam Sort
+      :> OrderParam
+      :> CursorParam
+      :> PageSizeParam
+      :> Http.Get '[JSON] (Page CommentDto)
   }
   deriving Generic
 
@@ -138,4 +157,5 @@ commentHandlers = CommentRoutes
   , getComment = CommentController.getComment
   , createComment = CommentController.createComment
   , deleteComment = CommentController.deleteComment
+  , getCommentComments = CommentController.getCommentComments
   }

--- a/src/Controllers/Api.hs
+++ b/src/Controllers/Api.hs
@@ -138,7 +138,7 @@ data CommentRoutes mode = CommentRoutes
       -- DELETE /comments/:commentId
       :- Capture "commentId" (Id Comment)
       :> Http.Delete '[JSON] Http.NoContent
-  , getCommentComments :: mode
+  , getCommentReplies :: mode
       -- GET /comments/:commentId/comments
       :- Capture "commentId" (Id Comment)
       :> "comments"
@@ -157,5 +157,5 @@ commentHandlers = CommentRoutes
   , getComment = CommentController.getComment
   , createComment = CommentController.createComment
   , deleteComment = CommentController.deleteComment
-  , getCommentComments = CommentController.getCommentComments
+  , getCommentReplies = CommentController.getCommentReplies
   }

--- a/src/Controllers/Api.hs
+++ b/src/Controllers/Api.hs
@@ -118,15 +118,7 @@ postHandlers = PostRoutes
   }
 
 data CommentRoutes mode = CommentRoutes
-  { getComments :: mode
-      -- GET /comments
-      :- QueryParam "postId" (Id Post)
-      :> SortByParam Sort
-      :> OrderParam
-      :> CursorParam
-      :> PageSizeParam
-      :> Http.Get '[JSON] (Page CommentDto)
-  , getComment :: mode
+  { getComment :: mode
       -- GET /comments/:commentId
       :- Capture "comment" (Id Comment)
       :> Http.Get '[JSON] CommentDto
@@ -153,8 +145,7 @@ data CommentRoutes mode = CommentRoutes
 commentHandlers :: (?requestCtx :: RequestContext)
   => CommentRoutes (AsServerT App)
 commentHandlers = CommentRoutes
-  { getComments = CommentController.getComments
-  , getComment = CommentController.getComment
+  { getComment = CommentController.getComment
   , createComment = CommentController.createComment
   , deleteComment = CommentController.deleteComment
   , getCommentReplies = CommentController.getCommentReplies

--- a/src/Controllers/CommentController.hs
+++ b/src/Controllers/CommentController.hs
@@ -6,8 +6,7 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Controllers.CommentController
-  ( getComments
-  , getComment
+  ( getComment
   , createComment
   , deleteComment
   , getPostComments
@@ -39,24 +38,6 @@ import qualified Stores.CommentStore as CommentStore
 import Stores.CommentStore (CommentStore)
 import qualified Stores.PostStore as PostStore
 import Stores.PostStore (PostStore)
-
-getComments :: (CommentStore m)
-  => Maybe (Id Post)
-  -> Maybe Sort
-  -> Maybe Order
-  -> Maybe Cursor
-  -> Maybe Int
-  -> m (Page CommentDto)
-getComments maybeId maybeSort maybeOrder maybeCursor maybePageSize = do
-  let
-    sorting = Sorting.make maybeSort maybeOrder
-    pageSize = fromMaybe Page.defaultPageSize maybePageSize
-  comments <- maybe CommentStore.findAll CommentStore.findByPost maybeId
-    sorting maybeCursor (1 + pageSize)
-  pure $ Page.make
-    (CommentDto.fromEntity <$> comments)
-    (Cursor.fromList sorting comments)
-    pageSize
 
 getComment :: (MonadThrow m, CommentStore m) => Id Comment -> m CommentDto
 getComment commentId = do

--- a/src/Controllers/CommentController.hs
+++ b/src/Controllers/CommentController.hs
@@ -11,7 +11,7 @@ module Controllers.CommentController
   , createComment
   , deleteComment
   , getPostComments
-  , getCommentComments
+  , getCommentReplies
   ) where
 
 import Control.Monad (when)
@@ -99,14 +99,14 @@ getPostComments :: (CommentStore m)
   -> m (Page CommentDto)
 getPostComments = getCommentsBy CommentStore.findByPost
 
-getCommentComments :: (CommentStore m)
+getCommentReplies :: (CommentStore m)
   => Id Comment
   -> Maybe Sort
   -> Maybe Order
   -> Maybe Cursor
   -> Maybe Int
   -> m (Page CommentDto)
-getCommentComments = getCommentsBy CommentStore.findByComment
+getCommentReplies = getCommentsBy CommentStore.findByComment
 
 getCommentsBy :: CommentStore m
   => (Id model -> Sorting -> Maybe Cursor -> Int -> m [Entity Comment])

--- a/src/Controllers/PostController.hs
+++ b/src/Controllers/PostController.hs
@@ -15,7 +15,7 @@ import Control.Monad (when)
 import Control.Monad.Catch (MonadThrow, throwM)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import qualified Controllers.Types.Error as Error
-import Data.Maybe (fromMaybe, listToMaybe)
+import Data.Maybe (fromMaybe)
 import Data.Time (getCurrentTime)
 import Dto.Page (Page(..), defaultPageSize)
 import qualified Dto.Page as Page
@@ -48,8 +48,10 @@ getPosts maybeId maybeSort maybeOrder maybeCursor maybePageSize = do
     pageSize = fromMaybe defaultPageSize maybePageSize
   posts <- maybe PostStore.findAll PostStore.findByAuthor maybeId
     sorting maybeCursor (1 + pageSize)
-  let nextCursor = Cursor.make sorting <$> (listToMaybe . reverse) posts
-  pure $ Page.make (PostDto.fromEntity <$> posts) nextCursor pageSize
+  pure $ Page.make
+    (PostDto.fromEntity <$> posts)
+    (Cursor.fromList sorting posts)
+    pageSize
 
 getPost :: (MonadThrow m, PostStore m) => Id Post -> m PostDto
 getPost postId = do

--- a/src/Dto/CommentDto.hs
+++ b/src/Dto/CommentDto.hs
@@ -19,6 +19,7 @@ import Data.Time (UTCTime)
 import Data.UUID (UUID)
 import GHC.Generics (Generic)
 import Models.Comment (Comment(..))
+import Models.Post (Post)
 import Models.Types.Entity (Entity(..))
 import Models.Types.Id (Id(..))
 import qualified Models.Types.Id as Id
@@ -61,23 +62,15 @@ toCommentId CommentIdDto{..} = Id commentId
 data NewCommentDto = NewCommentDto
   { title :: !Text
   , content :: !Text
-  , postId :: !UUID
-  , parentId :: !(Maybe UUID)
   }
   deriving (Show, Eq, Generic, FromJSON, ToJSON)
 
-toComment :: NewCommentDto -> Id User -> UTCTime -> UTCTime ->  Comment
-toComment
-  NewCommentDto
-    { postId
-    , parentId
-    , ..
-    }
-    userId
-    createdAt
-    updatedAt
-  = Comment
-    { postId = Id postId
-    , parentId = Id <$> parentId
-    , ..
-    }
+toComment :: NewCommentDto
+  -> Id User
+  -> Id Post
+  -> Maybe (Id Comment)
+  -> UTCTime
+  -> UTCTime
+  -> Comment
+toComment NewCommentDto {..} userId postId parentId createdAt updatedAt
+  = Comment {..}

--- a/src/Models/Comment.hs
+++ b/src/Models/Comment.hs
@@ -18,5 +18,6 @@ data Comment = Comment
   , updatedAt :: !UTCTime
   , postId :: !(Id Post)
   , userId :: !(Id User)
+  , parentId :: !(Maybe (Id Comment))
   }
   deriving (Show, Eq, Generic, FromRow, ToRow)

--- a/src/Models/Types/Cursor.hs
+++ b/src/Models/Types/Cursor.hs
@@ -8,8 +8,9 @@
 {-# LANGUAGE TypeApplications #-}
 
 module Models.Types.Cursor
- (Cursor(..), decode, encode, cursorExpression, make) where
+ (Cursor(..), decode, encode, cursorExpression, make, fromList) where
 
+import Data.Maybe (listToMaybe)
 import Data.String (IsString(..))
 import Data.Text (Text, pack, unpack)
 import Data.Text.Encoding.Base64 (decodeBase64, encodeBase64)
@@ -66,3 +67,10 @@ cursorExpression = \case
           Desc -> " <= "
       , "(", quote value, ", ", quote id', ")"
       ]
+
+fromList ::
+  ( HasField "createdAt" model UTCTime
+  , HasField "title" model Text
+  , HasField "updatedAt" model UTCTime
+  ) => Sorting -> [Entity model] -> Maybe Cursor
+fromList sorting entities = make sorting <$> (listToMaybe . reverse) entities

--- a/src/Models/Types/Id.hs
+++ b/src/Models/Types/Id.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE InstanceSigs #-}
 
-module Models.Types.Id (Id(..)) where
+module Models.Types.Id (Id(..), unwrap) where
 
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Text (Text)
@@ -26,3 +26,6 @@ instance Postgres.ToField (Id phantom) where
 instance Postgres.FromField (Id phantom) where
   fromField :: Postgres.FieldParser (Id phantom)
   fromField f s = Id <$> Postgres.fromField f s
+
+unwrap :: Id phantom -> UUID
+unwrap (Id uuid) = uuid

--- a/src/Stores/CommentStore.hs
+++ b/src/Stores/CommentStore.hs
@@ -25,7 +25,6 @@ import qualified Stores.Query as Query
 
 class Monad m => CommentStore m where
   find :: Id Comment -> m (Maybe (Entity Comment))
-  findAll :: Sorting -> Maybe Cursor -> Int -> m [Entity Comment]
   save :: Comment -> m (Maybe (Id Comment))
   delete :: Id Comment -> m ()
   findByPost :: Id Post -> Sorting -> Maybe Cursor -> Int -> m [Entity Comment]
@@ -43,19 +42,6 @@ instance CommentStore App where
       & withResource pool
       & liftIO
     pure (listToMaybe comments)
-
-  findAll :: Sorting -> Maybe Cursor -> Int -> App [Entity Comment]
-  findAll sorting maybeCursor count = do
-    pool <- asks (connectionPool . databaseContext)
-    Query.fetch
-        [ "SELECT id, title, content, created_at, updated_at, post_id, user_id, parent_comment_id"
-        , "FROM comments"
-        , maybe mempty (("WHERE " <>) . cursorExpression) maybeCursor
-        , "ORDER BY",  sortExpression sorting
-        , "FETCH FIRST ? ROWS ONLY"
-        ] [count]
-      & withResource pool
-      & liftIO
 
   save :: Comment -> App (Maybe (Id Comment))
   save Comment{..} = do

--- a/src/Stores/CommentStore.hs
+++ b/src/Stores/CommentStore.hs
@@ -29,13 +29,14 @@ class Monad m => CommentStore m where
   save :: Comment -> m (Maybe (Id Comment))
   delete :: Id Comment -> m ()
   findByPost :: Id Post -> Sorting -> Maybe Cursor -> Int -> m [Entity Comment]
+  findByComment :: Id Comment -> Sorting -> Maybe Cursor -> Int -> m [Entity Comment]
 
 instance CommentStore App where
   find :: Id Comment -> App (Maybe (Entity Comment))
   find idComment = do
     pool <- asks (connectionPool . databaseContext)
     comments <- Query.fetch
-        [ "SELECT id, title, content, created_at, updated_at, post_id, user_id"
+        [ "SELECT id, title, content, created_at, updated_at, post_id, user_id, parent_comment_id"
         , "FROM comments"
         , "WHERE id = ?"
         ] [idComment]
@@ -47,7 +48,7 @@ instance CommentStore App where
   findAll sorting maybeCursor count = do
     pool <- asks (connectionPool . databaseContext)
     Query.fetch
-        [ "SELECT id, title, content, created_at, updated_at, post_id, user_id"
+        [ "SELECT id, title, content, created_at, updated_at, post_id, user_id, parent_comment_id"
         , "FROM comments"
         , maybe mempty (("WHERE " <>) . cursorExpression) maybeCursor
         , "ORDER BY",  sortExpression sorting
@@ -61,10 +62,10 @@ instance CommentStore App where
     pool <- asks (connectionPool . databaseContext)
     ids <- Query.fetch
         [ "INSERT INTO comments"
-        , "(id, title, content, created_at, updated_at, post_id, user_id)"
-        , "VALUES (gen_random_uuid(), ?, ?, ?, ?, ?, ?)"
+        , "(id, title, content, created_at, updated_at, post_id, user_id, parent_comment_id)"
+        , "VALUES (gen_random_uuid(), ?, ?, ?, ?, ?, ?, ?)"
         , "RETURNING id"
-        ] (title, content, createdAt, updatedAt, postId, userId)
+        ] (title, content, createdAt, updatedAt, postId, userId, parentId)
       & withResource pool
       & liftIO
     pure (fromOnly <$> listToMaybe ids)
@@ -81,12 +82,27 @@ instance CommentStore App where
   findByPost idPost sorting maybeCursor count = do
     pool <- asks (connectionPool . databaseContext)
     Query.fetch
-        [ "SELECT id, title, content, created_at, updated_at, post_id, user_id"
+        [ "SELECT id, title, content, created_at, updated_at, post_id, user_id, parent_comment_id"
         , "FROM comments"
         , "WHERE post_id = ?"
         , maybe mempty (("AND " <>) . cursorExpression) maybeCursor
+        , "AND parent_comment_id IS NULL"
         , "ORDER BY", sortExpression sorting
         , "FETCH FIRST ? ROWS ONLY"
         ] (idPost, count)
+      & withResource pool
+      & liftIO
+
+  findByComment :: Id Comment -> Sorting -> Maybe Cursor -> Int -> App [Entity Comment]
+  findByComment idComment sorting maybeCursor count = do
+    pool <- asks (connectionPool . databaseContext)
+    Query.fetch
+        [ "SELECT id, title, content, created_at, updated_at, post_id, user_id, parent_comment_id"
+        , "FROM comments"
+        , "WHERE parent_comment_id = ?"
+        , maybe mempty (("AND " <>) . cursorExpression) maybeCursor
+        , "ORDER BY", sortExpression sorting
+        , "FETCH FIRST ? ROWS ONLY"
+        ] (idComment, count)
       & withResource pool
       & liftIO

--- a/test/Controllers/CommentControllerSpec.hs
+++ b/test/Controllers/CommentControllerSpec.hs
@@ -98,6 +98,7 @@ spec = do
           { NewCommentDto.title = "Title"
           , NewCommentDto.content = "Content"
           , NewCommentDto.postId = getUuid fstId
+          , NewCommentDto.parentId = Nothing
           }
 
       it "Creates the first comment" $ do
@@ -118,6 +119,7 @@ spec = do
         CommentDto.title comment `shouldBe` NewCommentDto.title newComment
         CommentDto.content comment `shouldBe` NewCommentDto.content newComment
         CommentDto.authorId comment `shouldBe` getUuid idUser
+        CommentDto.parentId comment `shouldBe` NewCommentDto.parentId newComment
 
       it "Throws error if commented post does not exist" $ do
         let newComment' = newComment{NewCommentDto.postId = nil}
@@ -134,6 +136,7 @@ spec = do
         , Comment.postId = fstId
         , Comment.createdAt = makeUtc "2022-09-12 00:00"
         , Comment.updatedAt = makeUtc "2022-09-12 00:00"
+        , Comment.parentId = Nothing
         }
       sndCommentId = makeId "e1da0ad5-d7fb-4c80-bb53-999d6e7c6147"
       sndCommentUser = makeId "0a6c8791-ab24-4b87-8289-411582c3bab7"
@@ -144,6 +147,7 @@ spec = do
         , Comment.postId = sndId
         , Comment.createdAt = makeUtc "2022-09-17 00:00"
         , Comment.updatedAt = makeUtc "2022-09-17 00:00"
+        , Comment.parentId = Nothing
         }
       thirdCommentId = makeId "b17e8ffa-f8ca-4169-8338-6bfb3a16c24c"
       thirdComment = Comment
@@ -153,6 +157,7 @@ spec = do
         , Comment.postId = sndId
         , Comment.createdAt = makeUtc "2022-09-10 00:00"
         , Comment.updatedAt = makeUtc "2022-09-10 00:00"
+        , Comment.parentId = Nothing
         }
       comments = Map.fromList
         [ (fstCommentId, Entity fstCommentId fstComment)

--- a/test/Mocks/CommentStore.hs
+++ b/test/Mocks/CommentStore.hs
@@ -7,6 +7,7 @@ module Mocks.CommentStore (CommentStore(..)) where
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.State (gets, modify)
 import qualified Data.Map.Strict as Map
+import Data.Maybe (isNothing)
 import Data.UUID.V4 (nextRandom)
 import Mocks.StorageMock (StorageMock)
 import qualified Mocks.StorageMock as StorageMock
@@ -45,12 +46,24 @@ instance CommentStore StorageMock where
     modify (\s -> s {StorageMock.comments = comments})
 
   findByPost :: Id Post -> Sorting -> Maybe Cursor -> Int -> StorageMock [Entity Comment]
-  findByPost idPost sorting maybeCursor n = gets
-    $ take n
-    . dropEntitiesBefore maybeCursor
-    . sortEntitiesBy sorting
-    . filter forPost
-    . Map.elems
-    . StorageMock.comments
-    where
-      forPost (Entity _ comment) = idPost == postId comment
+  findByPost = findBy
+    $ \idPost (Entity _ comment)
+      -> idPost == postId comment && isNothing (parentId comment)
+
+  findByComment :: Id Comment -> Sorting -> Maybe Cursor -> Int -> StorageMock [Entity Comment]
+  findByComment = findBy
+    $ \idComment (Entity _ comment) -> Just idComment == parentId comment
+
+findBy :: (Id model -> Entity Comment -> Bool)
+  -> Id model
+  -> Sorting
+  -> Maybe Cursor
+  -> Int
+  -> StorageMock [Entity Comment]
+findBy p modelId sorting maybeCursor n = gets
+  $ take n
+  . dropEntitiesBefore maybeCursor
+  . sortEntitiesBy sorting
+  . filter (p modelId)
+  . Map.elems
+  . StorageMock.comments

--- a/test/Mocks/CommentStore.hs
+++ b/test/Mocks/CommentStore.hs
@@ -24,14 +24,6 @@ instance CommentStore StorageMock where
   find :: Id Comment -> StorageMock (Maybe (Entity Comment))
   find commentId = gets (Map.lookup commentId . StorageMock.comments)
 
-  findAll :: Sorting -> Maybe Cursor -> Int -> StorageMock [Entity Comment]
-  findAll sorting maybeCursor n = gets
-    $ take n
-    . dropEntitiesBefore maybeCursor
-    . sortEntitiesBy sorting
-    . Map.elems
-    . StorageMock.comments
-
   save :: Comment -> StorageMock (Maybe (Id Comment))
   save comment = do
     commentId <- liftIO (Id <$> nextRandom)

--- a/test/Mocks/StorageMock.hs
+++ b/test/Mocks/StorageMock.hs
@@ -1,4 +1,10 @@
-module Mocks.StorageMock (runMock, StorageMock, Storage(..), emptyStorage) where
+module Mocks.StorageMock
+  ( runMock
+  , StorageMock
+  , Storage(..)
+  , emptyStorage
+  , storeFromList
+  ) where
 
 import Control.Monad.State (StateT, runStateT)
 import qualified Data.Map as Map
@@ -6,7 +12,7 @@ import Data.Map.Strict (Map)
 import Models.Comment (Comment)
 import Models.Credentials (Credentials)
 import Models.Post (Post)
-import Models.Types.Entity (Entity)
+import Models.Types.Entity (Entity(Entity))
 import Models.Types.Id (Id)
 import Models.User (User)
 
@@ -29,3 +35,6 @@ emptyStorage = MakeStorage
   , posts = Map.empty
   , comments = Map.empty
   }
+
+storeFromList :: [(Id model, model)] -> Map (Id model) (Entity model)
+storeFromList = Map.fromList . fmap (\(i, m) -> (i, Entity i m))


### PR DESCRIPTION
Support replies to comments.

- Adds `parent_comment_id` column to `comments` table
- Adds `POST /posts/:postId/comments` to create a post comment
- Adds `POST /comments/:commentId/comments` to create a comment reply
- Removes `POST /comments`
- `PostId` is removed from payload for new comments (now required in route)
- Adds `GET /posts/:postId/comments` to get a post comments (prevously implemented as `GET /comments?postId=***`)
- Adds `GET /comments/:commentId/comments` to get a comment replies
- Removes `GET /comments` (no use case left)