### PR TITLE
Add comment count endpoint

### DIFF
--- a/blog-api.cabal
+++ b/blog-api.cabal
@@ -35,6 +35,7 @@ library
       Controllers.UserController
       DatabaseContext
       Dto.CommentDto
+      Dto.CountDto
       Dto.Page
       Dto.PostDto
       Dto.UserDto

--- a/src/Controllers/Api.hs
+++ b/src/Controllers/Api.hs
@@ -13,6 +13,7 @@ import qualified Controllers.PostController as PostController
 import qualified Controllers.Types.Error as Error
 import qualified Controllers.UserController as UserController
 import Dto.CommentDto (CommentDto, CommentIdDto, NewCommentDto)
+import Dto.CountDto (CountDto)
 import Dto.Page (Page)
 import Dto.PostDto (NewPostDto, PostDto, PostIdDto)
 import Dto.UserDto (UserDto)
@@ -118,6 +119,12 @@ data PostRoutes mode = PostRoutes
       :> "comments"
       :> ReqBody Json NewCommentDto
       :> Http.Post Json CommentIdDto
+    , countComments :: mode
+      -- GET /posts/:postId/comments/count
+      :- Capture "postId" (Id Post)
+      :> "comments"
+      :> "count"
+      :> Http.Get Json CountDto
   }
   deriving Generic
 
@@ -130,6 +137,7 @@ postHandlers = PostRoutes
   , deletePost = PostController.deletePost
   , getPostComments = CommentController.getPostComments
   , createPostComment = CommentController.createPostComment
+  , countComments = CommentController.countComments
   }
 
 data CommentRoutes mode = CommentRoutes

--- a/src/Controllers/CommentController.hs
+++ b/src/Controllers/CommentController.hs
@@ -11,6 +11,7 @@ module Controllers.CommentController
   , deleteComment
   , getPostComments
   , getCommentReplies
+  , countComments
   ) where
 
 import Control.Monad (when)
@@ -22,6 +23,7 @@ import Data.Maybe (isNothing)
 import Data.Time (getCurrentTime)
 import Dto.CommentDto (CommentDto, CommentIdDto(..), NewCommentDto(..))
 import qualified Dto.CommentDto as CommentDto
+import Dto.CountDto (CountDto(..))
 import Dto.Page (Page)
 import qualified Dto.Page as Page
 import Models.Comment (Comment(..))
@@ -49,8 +51,8 @@ import Stores.PostStore (PostStore)
 
 getComment :: (MonadThrow m, CommentStore m) => Id Comment -> m CommentDto
 getComment commentId = CommentStore.find commentId >>= \case
-    Just comment -> pure (CommentDto.fromEntity comment)
-    Nothing -> throwM (Error.notFound "Could not find comment with such ID.")
+  Just comment -> pure (CommentDto.fromEntity comment)
+  Nothing -> throwM (Error.notFound "Could not find comment with such ID.")
 
 createPostComment :: (?requestCtx :: RequestContext)
   => (MonadThrow m, CommentStore m, PostStore m, MonadIO m)
@@ -127,3 +129,6 @@ createComment postId maybeParent dto = do
   CommentStore.save comment >>= \case
     Just (Id commentId) -> pure CommentIdDto {commentId}
     Nothing -> throwM (Error.serverError "Failed to create comment.")
+
+countComments :: (CommentStore m) => Id Post -> m CountDto
+countComments postId = CountDto <$> CommentStore.countByPost postId

--- a/src/Dto/CountDto.hs
+++ b/src/Dto/CountDto.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+
+module Dto.CountDto (CountDto(..)) where
+
+import Data.Aeson (ToJSON)
+import GHC.Generics (Generic)
+
+newtype CountDto = CountDto {count :: Int}
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass ToJSON

--- a/test/Mocks/CommentStore.hs
+++ b/test/Mocks/CommentStore.hs
@@ -44,6 +44,16 @@ instance CommentStore AppMock where
   findByComment = findBy
     $ \idComment (Entity _ comment) -> Just idComment == parentId comment
 
+  countByPost :: Id Post -> AppMock Int
+  countByPost idPost = gets
+    $ length
+    . filter topLevelByPost
+    . Map.elems
+    . AppMock.comments
+    where
+      topLevelByPost (Entity _ comment)
+        = idPost == postId comment && isNothing (parentId comment)
+
 findBy :: (Id model -> Entity Comment -> Bool)
   -> Id model
   -> Pagination


### PR DESCRIPTION
Adds `GET /posts/{postId}/comments/count`  to get the total number of comments a post has.

```json
{
  "count": 10
}
```