### PR TITLE
Add signup

### DIFF
--- a/blog-api.cabal
+++ b/blog-api.cabal
@@ -129,12 +129,14 @@ test-suite blog-api-test
       Controllers.CommentControllerSpec
       Controllers.PostControllerSpec
       Controllers.UserControllerSpec
+      Generators
       Mocks.AppMock
       Mocks.CommentStore
       Mocks.Logger
       Mocks.PostStore
       Mocks.TagStore
       Mocks.UserStore
+      Models.PasswordSpec
       Models.UsernameSpec
       Utils
       Paths_blog_api

--- a/blog-api.cabal
+++ b/blog-api.cabal
@@ -42,6 +42,8 @@ library
       LoggingContext
       Models.Comment
       Models.Credentials
+      Models.Email
+      Models.Password
       Models.Post
       Models.Tag
       Models.Types.Aggregate
@@ -51,6 +53,7 @@ library
       Models.Types.Pagination
       Models.Types.Sorting
       Models.User
+      Models.Username
       RequestContext
       Stores.CommentStore
       Stores.PostStore

--- a/blog-api.cabal
+++ b/blog-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -135,6 +135,7 @@ test-suite blog-api-test
       Mocks.PostStore
       Mocks.TagStore
       Mocks.UserStore
+      Models.UsernameSpec
       Utils
       Paths_blog_api
   hs-source-dirs:
@@ -143,7 +144,8 @@ test-suite blog-api-test
   build-tool-depends:
       hspec-discover:hspec-discover
   build-depends:
-      aeson
+      QuickCheck
+    , aeson
     , base >=4.7 && <5
     , base64
     , blog-api
@@ -156,6 +158,7 @@ test-suite blog-api-test
     , mtl
     , password
     , postgresql-simple
+    , quickcheck-instances
     , resource-pool
     , servant
     , servant-auth-server

--- a/blog-api.cabal
+++ b/blog-api.cabal
@@ -136,6 +136,7 @@ test-suite blog-api-test
       Mocks.PostStore
       Mocks.TagStore
       Mocks.UserStore
+      Models.EmailSpec
       Models.PasswordSpec
       Models.UsernameSpec
       Utils

--- a/package.yaml
+++ b/package.yaml
@@ -80,5 +80,7 @@ tests:
       - blog-api
       - containers
       - hspec
+      - QuickCheck
+      - quickcheck-instances
     build-tools:
       - hspec-discover:hspec-discover

--- a/src/Controllers/Api.hs
+++ b/src/Controllers/Api.hs
@@ -16,7 +16,7 @@ import Dto.CommentDto (CommentDto, CommentIdDto, NewCommentDto)
 import Dto.CountDto (CountDto)
 import Dto.Page (Page)
 import Dto.PostDto (NewPostDto, PostDto, PostIdDto)
-import Dto.UserDto (UserDto)
+import Dto.UserDto (NewUserDto, UserDto, UserIdDto)
 import GHC.Generics (Generic)
 import Models.Comment (Comment)
 import Models.Post (Post)
@@ -42,6 +42,11 @@ data Api mode = Api
       :- "login"
       :> ReqBody Json LoginRequest
       :> Http.Post Json LoginHeaders
+  , signup :: mode
+      -- POST /signup
+      :- "signup"
+      :> ReqBody Json NewUserDto
+      :> Http.Post Json UserIdDto
   , secured :: mode
       :- Sas.Auth Jwt (Entity User)
       :> NamedRoutes SecuredRoutes
@@ -51,6 +56,7 @@ data Api mode = Api
 handlers :: Sas.CookieSettings -> Sas.JWTSettings -> Api (AsServerT App)
 handlers cs jwts = Api
   { login = AuthController.login cs jwts
+  , signup = UserController.createUser
   , secured = securedHandlers
   }
 

--- a/src/Controllers/UserController.hs
+++ b/src/Controllers/UserController.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
 
 module Controllers.UserController (getUser, getCurrentUser, createUser) where
 
@@ -11,9 +10,13 @@ import Control.Monad.IO.Class (MonadIO)
 import qualified Controllers.Types.Error as Error
 import qualified Data.Password.Bcrypt as Bcrypt
 import Dto.UserDto (NewUserDto(..), UserDto, UserIdDto(..))
+import qualified Dto.UserDto as NewUserDto (NewUserDto(..))
 import qualified Dto.UserDto as UserDto
-import Models.Types.Id (Id, unwrap)
+import Models.Email (Email(..))
+import Models.Password (Password(..))
+import Models.Types.Id (Id(..))
 import Models.User (User(..))
+import Models.Username (Username(..))
 import RequestContext (RequestContext(..))
 import qualified Stores.UserStore as UserStore
 import Stores.UserStore (UserStore)
@@ -29,12 +32,15 @@ getCurrentUser :: (?requestCtx :: RequestContext)
 getCurrentUser = getUser (RequestContext.userId ?requestCtx)
 
 createUser :: (MonadThrow m, UserStore m, MonadIO m) => NewUserDto -> m UserIdDto
-createUser NewUserDto {..} = UserStore.findByUsername username >>= \case
+createUser dto = UserStore.findByUsername username >>= \case
   Nothing -> do
     hashed <- hash password
     UserStore.save (User username email) hashed >>= \case
-      Just userId -> pure $ UserIdDto (unwrap userId)
+      Just (Id userId) -> pure (UserIdDto userId)
       Nothing -> throwM (Error.serverError "Failed to create user.")
   Just _ -> throwM (Error.badRequest "Username already in use.")
   where
+    (Username username) = NewUserDto.username dto
+    (Email email) = NewUserDto.email dto
+    (Password password) = NewUserDto.password dto
     hash = Bcrypt.mkPassword >>> Bcrypt.hashPassword >>> fmap Bcrypt.unPasswordHash

--- a/src/Controllers/UserController.hs
+++ b/src/Controllers/UserController.hs
@@ -1,15 +1,19 @@
 {-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
-module Controllers.UserController (getUser, getCurrentUser) where
+module Controllers.UserController (getUser, getCurrentUser, createUser) where
 
+import Control.Category ((>>>))
 import Control.Monad.Catch (MonadThrow, throwM)
+import Control.Monad.IO.Class (MonadIO)
 import qualified Controllers.Types.Error as Error
-import Dto.UserDto (UserDto)
+import qualified Data.Password.Bcrypt as Bcrypt
+import Dto.UserDto (NewUserDto(..), UserDto, UserIdDto(..))
 import qualified Dto.UserDto as UserDto
-import Models.Types.Id (Id)
-import Models.User (User)
+import Models.Types.Id (Id, unwrap)
+import Models.User (User(..))
 import RequestContext (RequestContext(..))
 import qualified Stores.UserStore as UserStore
 import Stores.UserStore (UserStore)
@@ -23,3 +27,14 @@ getCurrentUser :: (?requestCtx :: RequestContext)
   => (MonadThrow m, UserStore m)
   => m UserDto
 getCurrentUser = getUser (RequestContext.userId ?requestCtx)
+
+createUser :: (MonadThrow m, UserStore m, MonadIO m) => NewUserDto -> m UserIdDto
+createUser NewUserDto {..} = UserStore.findByUsername username >>= \case
+  Nothing -> do
+    hashed <- hash password
+    UserStore.save (User username email) hashed >>= \case
+      Just userId -> pure $ UserIdDto (unwrap userId)
+      Nothing -> throwM (Error.serverError "Failed to create user.")
+  Just _ -> throwM (Error.badRequest "Username already in use.")
+  where
+    hash = Bcrypt.mkPassword >>> Bcrypt.hashPassword >>> fmap Bcrypt.unPasswordHash

--- a/src/Dto/UserDto.hs
+++ b/src/Dto/UserDto.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE RecordWildCards #-}
 
-module Dto.UserDto (UserDto(..), fromEntity) where
+module Dto.UserDto (UserDto(..), NewUserDto(..), fromEntity, UserIdDto(..)) where
 
-import Data.Aeson (ToJSON)
+import Data.Aeson (FromJSON, ToJSON)
 import Data.Text (Text)
 import Data.UUID (UUID)
 import GHC.Generics (Generic)
@@ -20,3 +22,15 @@ data UserDto = UserDto
 
 fromEntity :: Entity User -> UserDto
 fromEntity (Entity userId User {..}) = UserDto {userId = Id.unwrap userId, ..}
+
+data NewUserDto = NewUserDto
+  { username :: !Text
+  , email :: !Text
+  , password :: !Text
+  }
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass FromJSON
+
+newtype UserIdDto = UserIdDto {userId :: UUID}
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass ToJSON

--- a/src/Dto/UserDto.hs
+++ b/src/Dto/UserDto.hs
@@ -9,9 +9,12 @@ import Data.Aeson (FromJSON, ToJSON)
 import Data.Text (Text)
 import Data.UUID (UUID)
 import GHC.Generics (Generic)
+import Models.Email (Email)
+import Models.Password (Password)
 import Models.Types.Entity (Entity(..))
 import qualified Models.Types.Id as Id
 import Models.User (User(..))
+import Models.Username (Username)
 
 data UserDto = UserDto
   { userId :: !UUID
@@ -24,9 +27,9 @@ fromEntity :: Entity User -> UserDto
 fromEntity (Entity userId User {..}) = UserDto {userId = Id.unwrap userId, ..}
 
 data NewUserDto = NewUserDto
-  { username :: !Text
-  , email :: !Text
-  , password :: !Text
+  { username :: !Username
+  , email :: !Email
+  , password :: !Password
   }
   deriving stock (Show, Eq, Generic)
   deriving anyclass FromJSON

--- a/src/Models/Email.hs
+++ b/src/Models/Email.hs
@@ -17,7 +17,7 @@ pattern Email e <- MakeEmail e
 
 instance FromJSON Email where
   parseJSON :: Value -> Parser Email
-  parseJSON = withText "Email" $ \text -> either fail pure (makeEmail text)
+  parseJSON = withText "Email" (either fail pure . makeEmail)
 
 -- | Parses an email of the form x@y.z where all three x, y and z are at least 2
 -- characters long.

--- a/src/Models/Email.hs
+++ b/src/Models/Email.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+module Models.Email (Email(Email), makeEmail) where
+
+import Control.Arrow (second, (>>>))
+import Data.Aeson (FromJSON, parseJSON, withText)
+import Data.Aeson.Types (Parser, Value)
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+newtype Email = MakeEmail Text
+  deriving (Eq, Show)
+
+pattern Email :: Text -> Email
+pattern Email e <- MakeEmail e
+{-# COMPLETE Email #-}
+
+instance FromJSON Email where
+  parseJSON :: Value -> Parser Email
+  parseJSON = withText "Email" $ \text -> either fail pure (makeEmail text)
+
+-- | Parses an email of the form x@y.z where all three x, y and z are at least 2
+-- characters long.
+makeEmail :: Text -> Either String Email
+makeEmail text = if valid text then Right (MakeEmail text) else Left "invalid email"
+  where
+    valid = Text.break (== '@')
+      >>> second (Text.break (== '.'))
+      >>> \(a, (b, c)) -> (Text.length a > 1) && all (> 2) (Text.length <$> [b, c])
+

--- a/src/Models/Email.hs
+++ b/src/Models/Email.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE PatternSynonyms #-}
 
-module Models.Email (Email(Email), makeEmail) where
+module Models.Email (Email(Email), makeEmail, unsafeEmail) where
 
 import Control.Arrow (second, (>>>))
 import Data.Aeson (FromJSON, parseJSON, withText)
@@ -28,3 +28,5 @@ makeEmail text = if valid text then Right (MakeEmail text) else Left "invalid em
       >>> second (Text.break (== '.'))
       >>> \(a, (b, c)) -> (Text.length a > 1) && all (> 2) (Text.length <$> [b, c])
 
+unsafeEmail :: Text -> Email
+unsafeEmail = MakeEmail

--- a/src/Models/Password.hs
+++ b/src/Models/Password.hs
@@ -29,9 +29,10 @@ makePassword = fmap MakePassword . (validateLength >=> validateGroups)
     validateLength pswd = if Text.length pswd > 5
       then Right pswd
       else Left "password length is less than 6 chars"
-    validateGroups pswd = if not (emptyGroups pswd)
+    validateGroups pswd = if validAscii pswd && not (emptyGroups pswd)
       then Right pswd
       else Left "invalid password"
+    validAscii = Text.all (\c -> c >= '!' && c <= '~')
     emptyGroups = Text.partition isAlpha
       >>> second (Text.partition isDigit)
       >>> \(alpha, (digit, other)) -> any Text.null [alpha, digit, other]

--- a/src/Models/Password.hs
+++ b/src/Models/Password.hs
@@ -19,7 +19,7 @@ pattern Password e <- MakePassword e
 
 instance FromJSON Password where
   parseJSON :: Value -> Parser Password
-  parseJSON = withText "Password" $ \text -> either fail pure (makePassword text)
+  parseJSON = withText "Password" (either fail pure . makePassword)
 
 -- | Parses a password that is 6 or more characters long and contains at least
 -- one letter, one digit and one symbol.

--- a/src/Models/Password.hs
+++ b/src/Models/Password.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+module Models.Password (Password(Password), makePassword) where
+
+import Control.Arrow (second, (>>>))
+import Control.Monad ((>=>))
+import Data.Aeson (FromJSON, parseJSON, withText)
+import Data.Aeson.Types (Parser, Value)
+import Data.Char (isAlpha, isDigit)
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+newtype Password = MakePassword Text
+  deriving (Eq, Show)
+
+pattern Password :: Text -> Password
+pattern Password e <- MakePassword e
+{-# COMPLETE Password #-}
+
+instance FromJSON Password where
+  parseJSON :: Value -> Parser Password
+  parseJSON = withText "Password" $ \text -> either fail pure (makePassword text)
+
+-- | Parses a password that is 6 or more characters long and contains at least
+-- one letter, one digit and one symbol.
+makePassword :: Text -> Either String Password
+makePassword = fmap MakePassword . (validateLength >=> validateGroups)
+  where
+    validateLength pswd = if Text.length pswd > 5
+      then Right pswd
+      else Left "password length is less than 6 chars"
+    validateGroups pswd = if not (emptyGroups pswd)
+      then Right pswd
+      else Left "invalid password"
+    emptyGroups = Text.partition isAlpha
+      >>> second (Text.partition isDigit)
+      >>> \(alpha, (digit, other)) -> any Text.null [alpha, digit, other]

--- a/src/Models/Password.hs
+++ b/src/Models/Password.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE PatternSynonyms #-}
 
-module Models.Password (Password(Password), makePassword) where
+module Models.Password (Password(Password), makePassword, unsafePassword) where
 
 import Control.Arrow (second, (>>>))
 import Control.Monad ((>=>))
@@ -36,3 +36,6 @@ makePassword = fmap MakePassword . (validateLength >=> validateGroups)
     emptyGroups = Text.partition isAlpha
       >>> second (Text.partition isDigit)
       >>> \(alpha, (digit, other)) -> any Text.null [alpha, digit, other]
+
+unsafePassword :: Text -> Password
+unsafePassword = MakePassword

--- a/src/Models/Username.hs
+++ b/src/Models/Username.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+module Models.Username (Username(Username), makeUsername) where
+
+import Control.Category ((>>>))
+import Data.Aeson (FromJSON, parseJSON, withText)
+import Data.Aeson.Types (Parser, Value)
+import Data.Char (isAlpha, isDigit)
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+newtype Username = MakeUsername Text
+  deriving (Eq, Show)
+
+pattern Username :: Text -> Username
+pattern Username e <- MakeUsername e
+{-# COMPLETE Username #-}
+
+instance FromJSON Username where
+  parseJSON :: Value -> Parser Username
+  parseJSON = withText "Username" $ \text -> either fail pure (makeUsername text)
+
+-- | Parses a username that is 4 or more characters long and it's made of letters,
+-- digits and '_' or '-'.
+makeUsername :: Text -> Either String Username
+makeUsername text = if valid text
+  then Right (MakeUsername text)
+  else Left "invalid username"
+  where
+    validChar c = isAlpha c || isDigit c || c == '_' || c == '-'
+    valid = Text.partition validChar
+      >>> \(accepted, other) -> (Text.length accepted > 3) && Text.null other

--- a/src/Models/Username.hs
+++ b/src/Models/Username.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE PatternSynonyms #-}
 
-module Models.Username (Username(Username), makeUsername) where
+module Models.Username (Username(Username), makeUsername, unsafeUsername) where
 
 import Control.Category ((>>>))
 import Data.Aeson (FromJSON, parseJSON, withText)
@@ -34,3 +34,6 @@ makeUsername text = if valid text
      || c == '-'
     valid = Text.partition validChar
       >>> \(accepted, other) -> (Text.length accepted > 3) && Text.null other
+
+unsafeUsername :: Text -> Username
+unsafeUsername = MakeUsername

--- a/src/Models/Username.hs
+++ b/src/Models/Username.hs
@@ -5,7 +5,7 @@ module Models.Username (Username(Username), makeUsername) where
 import Control.Category ((>>>))
 import Data.Aeson (FromJSON, parseJSON, withText)
 import Data.Aeson.Types (Parser, Value)
-import Data.Char (isAlpha, isDigit)
+import Data.Char (isAsciiLower, isAsciiUpper, isDigit)
 import Data.Text (Text)
 import qualified Data.Text as Text
 
@@ -27,6 +27,10 @@ makeUsername text = if valid text
   then Right (MakeUsername text)
   else Left "invalid username"
   where
-    validChar c = isAlpha c || isDigit c || c == '_' || c == '-'
+    validChar c = isAsciiUpper c
+     || isAsciiLower c
+     || isDigit c
+     || c == '_'
+     || c == '-'
     valid = Text.partition validChar
       >>> \(accepted, other) -> (Text.length accepted > 3) && Text.null other

--- a/src/Models/Username.hs
+++ b/src/Models/Username.hs
@@ -18,7 +18,7 @@ pattern Username e <- MakeUsername e
 
 instance FromJSON Username where
   parseJSON :: Value -> Parser Username
-  parseJSON = withText "Username" $ \text -> either fail pure (makeUsername text)
+  parseJSON = withText "Username" (either fail pure . makeUsername)
 
 -- | Parses a username that is 4 or more characters long and it's made of letters,
 -- digits and '_' or '-'.

--- a/src/Stores/UserStore.hs
+++ b/src/Stores/UserStore.hs
@@ -22,8 +22,10 @@ import qualified Stores.Query as Query
 
 class Monad m => UserStore m where
   find :: Id User -> m (Maybe (Entity User))
-  save :: User -> m (Maybe (Id User))
+  save :: User -> Text -> m (Maybe (Id User))
+  -- save :: User -> m (Maybe (Id User))
   findWithCredentials :: Text -> m (Maybe (Aggregate User Credentials))
+  findByUsername :: Text -> m (Maybe (Entity User))
 
 instance UserStore App where
   find :: Id User -> App (Maybe (Entity User))
@@ -35,14 +37,18 @@ instance UserStore App where
       & liftIO
     pure (listToMaybe users)
 
-  save :: User -> App (Maybe (Id User))
-  save user = do
+  save :: User -> Text -> App (Maybe (Id User))
+  save user psw = do
     pool <- asks (connectionPool . databaseContext)
     ids <- Query.fetch
-        [ "INSERT INTO users (id, username, email)"
-        , "VALUES (gen_random_uuid(), ?, ?)"
-        , "RETURNING id"
-        ] (username user, email user)
+        [ "WITH newUser AS ("
+        , "  INSERT INTO users (id, username, email)"
+        , "  VALUES (gen_random_uuid(), ?, ?)"
+        , "  RETURNING id )"
+        , "INSERT INTO user_credentials"
+        , "VALUES ((SELECT id AS user_id FROM newUser), ?)"
+        , "RETURNING user_id"
+        ] (username user, email user, psw)
       & withResource pool
       & liftIO
     pure (fromOnly <$> listToMaybe ids)
@@ -56,6 +62,15 @@ instance UserStore App where
         , "INNER JOIN user_credentials ON id = user_id"
         , "WHERE username = ?"
         ] [aUsername]
+      & withResource pool
+      & liftIO
+    pure (listToMaybe users)
+
+  findByUsername :: Text -> App (Maybe (Entity User))
+  findByUsername aUsername = do
+    pool <- asks (connectionPool . databaseContext)
+    users <- Query.fetch
+        ["SELECT id, username, email FROM users WHERE username = ?"] [aUsername]
       & withResource pool
       & liftIO
     pure (listToMaybe users)

--- a/src/Stores/UserStore.hs
+++ b/src/Stores/UserStore.hs
@@ -23,7 +23,6 @@ import qualified Stores.Query as Query
 class Monad m => UserStore m where
   find :: Id User -> m (Maybe (Entity User))
   save :: User -> Text -> m (Maybe (Id User))
-  -- save :: User -> m (Maybe (Id User))
   findWithCredentials :: Text -> m (Maybe (Aggregate User Credentials))
   findByUsername :: Text -> m (Maybe (Entity User))
 

--- a/test/Controllers/UserControllerSpec.hs
+++ b/test/Controllers/UserControllerSpec.hs
@@ -3,17 +3,23 @@
 
 module Controllers.UserControllerSpec (spec) where
 
-import Controllers.UserController (getUser)
+import Controllers.UserController (createUser, getUser)
 import qualified Data.Map as Map
 import Data.UUID (nil)
+import Dto.UserDto (NewUserDto(NewUserDto))
+import qualified Dto.UserDto as NewUserDto (NewUserDto(..))
 import qualified Dto.UserDto as UserDto (UserDto(..))
+import qualified Dto.UserDto as UserIdDto (UserIdDto(..))
 import Mocks.AppMock (runMock)
 import qualified Mocks.AppMock as AppMock
 import Mocks.UserStore ()
+import Models.Email (unsafeEmail)
+import Models.Password (unsafePassword)
 import Models.Types.Entity (Entity(..))
 import Models.Types.Id (Id(..))
 import Models.User (User(..))
 import qualified Models.User as User
+import Models.Username (unsafeUsername)
 import RequestContext (RequestContext(..))
 import Test.Hspec (Spec, context, describe, it, shouldBe, shouldThrow)
 import Utils (makeId, serverError)
@@ -41,3 +47,25 @@ spec = do
 
       it "Throws error if not found" $ do
         runMock (getUser (Id nil)) givenUsers `shouldThrow` serverError 404
+
+    context "When creating a user" $ do
+      it "Finds the new user" $ do
+        let
+          newUser = NewUserDto
+            { NewUserDto.username = unsafeUsername "new_user"
+            , NewUserDto.email = unsafeEmail "new_u@mail.com"
+            , NewUserDto.password = unsafePassword "abc123$"
+            }
+          createThenGet = createUser newUser >>= getUser . Id . UserIdDto.userId
+        user <- runMock createThenGet givenUsers
+        UserDto.username user `shouldBe` "new_user"
+        UserDto.email user `shouldBe` "new_u@mail.com"
+
+      it "Throws error if username already exists" $ do
+        let
+          newUser = NewUserDto
+            { NewUserDto.username = unsafeUsername "username"
+            , NewUserDto.email = unsafeEmail "new_u@mail.com"
+            , NewUserDto.password = unsafePassword "abc123$"
+            }
+        runMock (createUser newUser) givenUsers `shouldThrow` serverError 400

--- a/test/Controllers/UserControllerSpec.hs
+++ b/test/Controllers/UserControllerSpec.hs
@@ -6,7 +6,7 @@ module Controllers.UserControllerSpec (spec) where
 import Controllers.UserController (getUser)
 import qualified Data.Map as Map
 import Data.UUID (nil)
-import qualified Dto.UserDto as UserDto
+import qualified Dto.UserDto as UserDto (UserDto(..))
 import Mocks.AppMock (runMock)
 import qualified Mocks.AppMock as AppMock
 import Mocks.UserStore ()

--- a/test/Generators.hs
+++ b/test/Generators.hs
@@ -1,0 +1,10 @@
+module Generators (listOfN) where
+
+import Test.QuickCheck (Gen, chooseInt, sized, vectorOf)
+
+-- | Generates a minimum-sized list of random length. The maximum length depends
+-- on the size parameter.
+listOfN :: Int -> Gen a -> Gen [a]
+listOfN n gen = sized $ \m -> do
+  k <- chooseInt (n, max n m)
+  vectorOf k gen

--- a/test/Mocks/UserStore.hs
+++ b/test/Mocks/UserStore.hs
@@ -4,18 +4,18 @@ module Mocks.UserStore (UserStore (..)) where
 
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.State (gets, modify)
-import Data.List qualified as List
-import Data.Map.Strict qualified as Map
+import qualified Data.List as List
+import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import Data.UUID.V4 (nextRandom)
 import Mocks.AppMock (AppMock)
-import Mocks.AppMock qualified as AppMock
-import Models.Credentials (Credentials (..))
-import Models.Types.Aggregate (Aggregate (Aggregate))
-import Models.Types.Entity (Entity (Entity))
-import Models.Types.Id (Id (..))
-import Models.User (User (..))
-import Stores.UserStore (UserStore (..))
+import qualified Mocks.AppMock as AppMock
+import Models.Credentials (Credentials(..))
+import Models.Types.Aggregate (Aggregate(Aggregate))
+import Models.Types.Entity (Entity(Entity))
+import Models.Types.Id (Id(..))
+import Models.User (User(..))
+import Stores.UserStore (UserStore(..))
 
 instance UserStore AppMock where
   find :: Id User -> AppMock (Maybe (Entity User))
@@ -42,7 +42,7 @@ instance UserStore AppMock where
     pure (Just idUser)
 
   findByUsername :: Text -> AppMock (Maybe (Entity User))
-  findByUsername username' = gets 
+  findByUsername username' = gets
     $ List.find (\(Entity _ user) -> username user == username')
     . Map.elems
     . AppMock.users

--- a/test/Mocks/UserStore.hs
+++ b/test/Mocks/UserStore.hs
@@ -1,6 +1,6 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Mocks.UserStore (UserStore (..)) where
+module Mocks.UserStore (UserStore(..)) where
 
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.State (gets, modify)

--- a/test/Models/EmailSpec.hs
+++ b/test/Models/EmailSpec.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Models.EmailSpec (spec) where
+
+import Data.Either (isLeft)
+import Data.Text (pack)
+import Generators (listOfN)
+import Models.Email (Email(Email), makeEmail)
+import Test.Hspec (Spec, describe, it, shouldSatisfy)
+import Test.Hspec.QuickCheck (prop)
+import Test.QuickCheck
+  (arbitrary, chooseEnum, forAll, frequency, listOf, suchThat)
+
+spec :: Spec
+spec = do
+  describe "makeEmail" $ do
+    prop "Valid content produces an Email" $
+      forAll email $ \x -> makeEmail x `shouldSatisfy` wraps x
+
+    prop "Fails with invalid content" $
+      forAll invalidEmail $ \x -> makeEmail x `shouldSatisfy` isLeft
+
+    it "Fails when empty" $
+      makeEmail "" `shouldSatisfy` isLeft
+
+    where
+      wraps x = either (const False) (\(Email e) -> e == x)
+      email = pack <$> do
+        a <- listOfN 2 (arbitrary `suchThat` (/= '@'))
+        b <- listOfN 2 (arbitrary `suchThat` (/= '.'))
+        c <- listOfN 2 arbitrary
+        pure (mconcat [a, ['@'], b, ['.'], c])
+      invalidEmail = pack <$> do
+        selectAt <- chooseEnum (True, False)
+        let (sel, excl) = if selectAt then ('@', '.') else ('.', '@')
+        listOf $ frequency
+          [ (1, arbitrary `suchThat` (== sel))
+          , (8, arbitrary `suchThat` (/= excl))
+          ]

--- a/test/Models/PasswordSpec.hs
+++ b/test/Models/PasswordSpec.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Models.PasswordSpec (spec) where
+
+import Data.Char (isAlpha, isDigit, isSymbol)
+import Data.Either (isLeft)
+import Data.Text (pack)
+import Generators (listOfN)
+import Models.Password (Password(Password), makePassword)
+import Test.Hspec (Spec, describe, it, shouldSatisfy)
+import Test.Hspec.QuickCheck (prop)
+import Test.QuickCheck
+  (arbitrary, chooseInt, forAll, listOf, oneof, shuffle, suchThat)
+
+spec :: Spec
+spec = do
+  describe "makePassword" $ do
+    prop "Valid lenght and content produces a password" $
+      forAll password $ \x -> makePassword x `shouldSatisfy` wraps x
+
+    prop "Fails with an invalid char" $
+      forAll invalidPassword $ \x -> makePassword x `shouldSatisfy` isLeft
+
+    prop "Fails without all three char types" $
+      forAll invalidPassword' $ \x -> makePassword x `shouldSatisfy` isLeft
+
+    it "Fails when empty" $
+      makePassword "" `shouldSatisfy` isLeft
+
+  where
+    wraps x = either (const False) (\(Password p) -> p == x)
+    isValid c = c >= '!' && c <= '~'
+    alphaGen = arbitrary `suchThat` (\c -> isValid c && isAlpha c)
+    digitGen = arbitrary `suchThat` (\c -> isValid c && isDigit c)
+    symbolGen = arbitrary `suchThat` (\c -> isValid c && isSymbol c)
+    validGen = arbitrary `suchThat` isValid
+    invalidGen = arbitrary `suchThat` (not . isValid)
+    password = pack <$> do
+      alpha <- alphaGen
+      digit <- digitGen
+      symbol <- symbolGen
+      rest <- listOfN 3 validGen
+      shuffle (alpha : digit : symbol : rest)
+    invalidPassword = pack <$> do
+      invalid <- invalidGen
+      rest <- listOf $ oneof [alphaGen, digitGen, symbolGen, invalidGen]
+      shuffle (invalid : rest)
+    invalidPassword' = pack <$> do
+      k <- chooseInt (0, 2)
+      listOf $ (oneof . take 2 . drop k) [alphaGen, digitGen, symbolGen, alphaGen]

--- a/test/Models/UsernameSpec.hs
+++ b/test/Models/UsernameSpec.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Models.UsernameSpec (spec) where
+
+import Data.Either (isLeft)
+import Data.Text (pack)
+import Models.Username (Username(Username), makeUsername)
+import Test.Hspec (Spec, describe, it, shouldSatisfy)
+import Test.Hspec.QuickCheck (prop)
+import Test.QuickCheck
+  (Gen, arbitrary, chooseInt, forAll, shuffle, sized, suchThat, vectorOf)
+import Test.QuickCheck.Instances.Text ()
+
+spec :: Spec
+spec = do
+  describe "makeUsername" $ do
+    prop "Valid lenght and content produces a username" $
+      forAll username $ \x -> makeUsername x `shouldSatisfy` wraps x
+
+    prop "Fails with an invalid char" $
+      forAll invalidUsername $ \x -> makeUsername x `shouldSatisfy` isLeft
+
+    it "Fails when empty" $
+      makeUsername "" `shouldSatisfy` isLeft
+
+  where
+    wraps x = \case
+      Right (Username u) -> u == x
+      Left _ -> False
+    isValid = (`elem` ['A'..'Z'] <> ['a'..'z'] <> ['0'..'9'] <> ['-','_'])
+    username = pack <$> listN 4 (arbitrary `suchThat` isValid)
+    invalidUsername = pack <$> do
+      invalid <- arbitrary `suchThat` (not . isValid)
+      validList <- listN 0 (arbitrary `suchThat` isValid)
+      shuffle (invalid : validList)
+
+listN :: Int -> Gen Char -> Gen [Char]
+listN n gen = sized $ \m -> do
+  k <- chooseInt (n, max n m)
+  vectorOf k gen


### PR DESCRIPTION
Adds `POST /signup` to register a new user.

```json
{
  "username": "user_14",
  "password": "abc123%",
  "email": "user@mail.com"
}
```

All three fields are validated when parsed:

- `username` expects ASCII letters, digits, `_` and `-`. 4 or more characters long.
- `password` expects ASCII letters, digits and any of ``! " # $ % & ' ( ) * + , - . / : ; < = > ? @ [ \ ] ^ _ ` { | } ~``. 6 or more characters long.
- `email` expects a general `xx@yy.zz` format with no further restrictions.

Additionally, `username` must be unique.