### PR TITLE
Migrate from SAS to Generalised Auth

### DIFF
--- a/blog-api.cabal
+++ b/blog-api.cabal
@@ -26,6 +26,8 @@ library
   exposed-modules:
       App
       AppContext
+      Auth
+      AuthClaims
       Controllers.Api
       Controllers.AuthController
       Controllers.CommentController
@@ -61,6 +63,7 @@ library
       Stores.Query
       Stores.TagStore
       Stores.UserStore
+      ThrowAll
   other-modules:
       Paths_blog_api
   hs-source-dirs:
@@ -74,12 +77,12 @@ library
     , exceptions
     , fast-logger
     , jose
+    , lens
     , mtl
     , password
     , postgresql-simple
     , resource-pool
     , servant
-    , servant-auth-server
     , servant-client
     , servant-server
     , text
@@ -106,12 +109,12 @@ executable blog-api-exe
     , exceptions
     , fast-logger
     , jose
+    , lens
     , mtl
     , password
     , postgresql-simple
     , resource-pool
     , servant
-    , servant-auth-server
     , servant-client
     , servant-server
     , text
@@ -159,13 +162,13 @@ test-suite blog-api-test
     , fast-logger
     , hspec
     , jose
+    , lens
     , mtl
     , password
     , postgresql-simple
     , quickcheck-instances
     , resource-pool
     , servant
-    , servant-auth-server
     , servant-client
     , servant-server
     , text

--- a/package.yaml
+++ b/package.yaml
@@ -28,12 +28,12 @@ dependencies:
   - exceptions
   - fast-logger
   - jose
+  - lens
   - mtl
   - password
   - postgresql-simple
   - resource-pool
   - servant
-  - servant-auth-server
   - servant-client
   - servant-server
   - text

--- a/src/App.hs
+++ b/src/App.hs
@@ -9,8 +9,8 @@ import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Reader (ReaderT(runReaderT))
 import Control.Monad.Reader.Class (MonadReader)
 import Servant (Handler(..))
-import Servant.Auth.Server (ThrowAll(..))
 import Servant.Server (ServerError)
+import ThrowAll (ThrowAll(..))
 
 newtype App a = App (ReaderT AppContext IO a)
   deriving

--- a/src/Auth.hs
+++ b/src/Auth.hs
@@ -42,13 +42,13 @@ getToken req = do
 
 verifyToken :: (HasClaimsSet a, FromJSON a)
   => JWK -> JWTValidationSettings -> ByteString -> IO (Maybe a)
-verifyToken jwk settings token = fromRight <$> runJOSE @JWTError verify
+verifyToken jwk settings token = maybeRight <$> runJOSE @JWTError verify
   where
     verify = decodeCompact lazy >>= verifyJWT settings jwk
     lazy = LazyByteString.fromString (ByteString.toString token)
 
 signToken :: (ToJSON a) => JWK -> a -> IO (Maybe SignedJWT)
-signToken jwk claims = fromRight <$> runJOSE @JWTError sign
+signToken jwk claims = maybeRight <$> runJOSE @JWTError sign
   where
     sign = do
       alg <- bestJWSAlg jwk
@@ -60,5 +60,5 @@ generateKey = genJWK (OctGenParam 256)
 fromSecret :: ByteString -> JWK
 fromSecret = fromOctets
 
-fromRight :: Either a b -> Maybe b
-fromRight = either (const Nothing) Just
+maybeRight :: Either a b -> Maybe b
+maybeRight = either (const Nothing) Just

--- a/src/Auth.hs
+++ b/src/Auth.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Auth (authHandler, signToken, generateKey, fromSecret) where
+
+import Control.Arrow (second, (>>>))
+import Control.Monad (guard)
+import Control.Monad.Except (throwError)
+import Control.Monad.IO.Class (liftIO)
+import qualified Controllers.Types.Error as Error
+import Crypto.JOSE
+  ( JWK
+  , KeyMaterialGenParam(OctGenParam)
+  , bestJWSAlg
+  , decodeCompact
+  , fromOctets
+  , genJWK
+  , newJWSHeader
+  , runJOSE
+  )
+import Crypto.JWT
+  (HasClaimsSet, JWTError, JWTValidationSettings, SignedJWT, signJWT, verifyJWT)
+import Data.Aeson (FromJSON, ToJSON)
+import qualified Data.ByteString.Lazy.UTF8 as LazyByteString
+import Data.ByteString.UTF8 (ByteString)
+import qualified Data.ByteString.UTF8 as ByteString
+import Network.Wai (Request, requestHeaders)
+import Servant.Server.Experimental.Auth (AuthHandler, mkAuthHandler)
+
+authHandler :: (HasClaimsSet a, FromJSON a)
+  => JWK -> JWTValidationSettings -> AuthHandler Request a
+authHandler jwk settings = mkAuthHandler handleAuth
+  where
+    handleAuth req = checkAuth (getToken req)
+      >>= liftIO . verifyToken jwk settings
+      >>= checkAuth
+    checkAuth = maybe (throwError Error.unauthorized) pure
+
+getToken :: Request -> Maybe ByteString
+getToken req = do
+  (scheme, token) <- split <$> lookup "Authorization" (requestHeaders req)
+  guard (scheme == "Bearer")
+  pure token
+  where
+    split = ByteString.break (== ' ') >>> second (ByteString.drop 1)
+
+verifyToken :: (HasClaimsSet a, FromJSON a)
+  => JWK -> JWTValidationSettings -> ByteString -> IO (Maybe a)
+verifyToken jwk settings token = fromRight <$> runJOSE @JWTError verify
+  where
+    verify = decodeCompact lazy >>= verifyJWT settings jwk
+    lazy = LazyByteString.fromString (ByteString.toString token)
+
+signToken :: (ToJSON a) => JWK -> a -> IO (Maybe SignedJWT)
+signToken jwk claims = fromRight <$> runJOSE @JWTError sign
+  where
+    sign = do
+      alg <- bestJWSAlg jwk
+      signJWT jwk (newJWSHeader ((), alg)) claims
+
+generateKey :: IO JWK
+generateKey = genJWK (OctGenParam 256)
+
+fromSecret :: ByteString -> JWK
+fromSecret = fromOctets
+
+fromRight :: Either a b -> Maybe b
+fromRight = either (const Nothing) Just

--- a/src/AuthClaims.hs
+++ b/src/AuthClaims.hs
@@ -17,12 +17,14 @@ import Crypto.JWT
   ( Audience(..)
   , ClaimsSet
   , HasClaimsSet(..)
+  , JWTValidationSettings
   , NumericDate(..)
   , claimExp
   , claimIat
   , claimSub
+  , defaultJWTValidationSettings
   , emptyClaimsSet
-  , string, defaultJWTValidationSettings, JWTValidationSettings
+  , string
   )
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Function ((&))
@@ -69,7 +71,7 @@ refreshClaims (Id userId) issuedAt = emptyClaimsSet
   & RefreshClaims
 
 refreshSettings :: JWTValidationSettings
-refreshSettings = defaultJWTValidationSettings (== "access")
+refreshSettings = defaultJWTValidationSettings (== "refresh")
 
 subjectClaim :: HasClaimsSet a => a -> Maybe (Id User)
 subjectClaim c = Id <$> (view claimSub c >>= Uuid.fromText . view string)

--- a/src/AuthClaims.hs
+++ b/src/AuthClaims.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module AuthClaims
+  ( AccessClaims(..)
+  , RefreshClaims(..)
+  , accessClaims
+  , accessSettings
+  , refreshClaims
+  , refreshSettings
+  , subjectClaim
+  ) where
+
+import Control.Lens (Lens', view, (?~))
+import Crypto.JWT
+  ( Audience(..)
+  , ClaimsSet
+  , HasClaimsSet(..)
+  , NumericDate(..)
+  , claimExp
+  , claimIat
+  , claimSub
+  , emptyClaimsSet
+  , string, defaultJWTValidationSettings, JWTValidationSettings
+  )
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Function ((&))
+import Data.String (fromString)
+import Data.Time (UTCTime, addUTCTime)
+import qualified Data.UUID as Uuid
+import GHC.Generics (Generic)
+import Models.Types.Id (Id(..))
+import Models.User (User)
+
+newtype AccessClaims = AccessClaims ClaimsSet
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+instance HasClaimsSet AccessClaims where
+  claimsSet :: Lens' AccessClaims ClaimsSet
+  claimsSet f (AccessClaims claims) = AccessClaims <$> f claims
+
+accessClaims :: Id User -> UTCTime -> AccessClaims
+accessClaims (Id userId) issuedAt = emptyClaimsSet
+  & claimSub ?~ fromString (Uuid.toString userId)
+  & claimIat ?~ NumericDate issuedAt
+  & claimExp ?~ NumericDate (addUTCTime 900 issuedAt)
+  & claimAud ?~ Audience ["access"]
+  & AccessClaims
+
+accessSettings :: JWTValidationSettings
+accessSettings = defaultJWTValidationSettings (== "access")
+
+newtype RefreshClaims = RefreshClaims ClaimsSet
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+instance HasClaimsSet RefreshClaims where
+  claimsSet :: Lens' RefreshClaims ClaimsSet
+  claimsSet f (RefreshClaims claims) = RefreshClaims <$> f claims
+
+refreshClaims :: Id User -> UTCTime -> RefreshClaims
+refreshClaims (Id userId) issuedAt = emptyClaimsSet
+  & claimSub ?~ fromString (Uuid.toString userId)
+  & claimIat ?~ NumericDate issuedAt
+  & claimExp ?~ NumericDate (addUTCTime 86400 issuedAt)
+  & claimAud ?~ Audience ["refresh"]
+  & RefreshClaims
+
+refreshSettings :: JWTValidationSettings
+refreshSettings = defaultJWTValidationSettings (== "access")
+
+subjectClaim :: HasClaimsSet a => a -> Maybe (Id User)
+subjectClaim c = Id <$> (view claimSub c >>= Uuid.fromText . view string)

--- a/src/Controllers/Api.hs
+++ b/src/Controllers/Api.hs
@@ -49,6 +49,11 @@ data Api mode = Api
       :- "login"
       :> ReqBody Json LoginRequest
       :> Http.Post Json LoginResponse
+  , refresh :: mode
+      -- POST /refresh
+      :- "refresh"
+      :> AuthJwtRefresh
+      :> Http.Post Json LoginResponse
   , signup :: mode
       -- POST /signup
       :- "signup"
@@ -63,6 +68,7 @@ data Api mode = Api
 handlers :: JWK -> Api (AsServerT App)
 handlers jwk = Api
   { login = AuthController.login jwk
+  , refresh = AuthController.refreshToken jwk
   , signup = UserController.createUser
   , secured = securedHandlers
   }

--- a/src/Controllers/AuthController.hs
+++ b/src/Controllers/AuthController.hs
@@ -1,23 +1,29 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ViewPatterns #-}
 
-module Controllers.AuthController (LoginHeaders, login, LoginRequest(..)) where
+module Controllers.AuthController (login, LoginRequest(..), LoginResponse(..)) where
 
-import Control.Monad (when)
+import Auth (signToken)
+import AuthClaims (accessClaims, refreshClaims)
+import Control.Monad (liftM2, when)
 import Control.Monad.Catch (MonadThrow, throwM)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import qualified Controllers.Types.Error as Error
-import Data.Aeson (FromJSON)
+import Crypto.JOSE (JWK)
+import qualified Crypto.JWT as Jwt
+import Data.Aeson (FromJSON, ToJSON)
+import qualified Data.ByteString.Lazy.UTF8 as LazyByteString
 import qualified Data.Password.Bcrypt as Bcrypt
 import Data.Text (Text)
+import Data.Time (getCurrentTime)
 import GHC.Generics (Generic)
 import Models.Credentials (Credentials(..))
 import Models.HashedPassword (HashedPassword(HashedPassword))
 import Models.Types.Aggregate (Aggregate(Aggregate))
+import Models.Types.Entity (Entity(..))
 import Models.Username (makeUsername)
-import qualified Servant as Http (Header, Headers, NoContent(..))
-import qualified Servant.Auth.Server as Sas
 import qualified Stores.UserStore as UserStore
 import Stores.UserStore (UserStore)
 
@@ -27,26 +33,35 @@ data LoginRequest = LoginRequest
   }
   deriving (Generic, FromJSON)
 
-type LoginHeaders = Http.Headers
-  '[ Http.Header "Set-Cookie" Sas.SetCookie
-   , Http.Header "Set-Cookie" Sas.SetCookie ]
-  Http.NoContent
+data LoginResponse = LoginResponse
+  { access :: !String
+  , refresh :: !String
+  }
+  deriving (Generic, ToJSON)
 
 login :: (MonadThrow m, UserStore m, MonadIO m)
-  => Sas.CookieSettings -> Sas.JWTSettings -> LoginRequest -> m LoginHeaders
-login cookieSettings jwtSettings LoginRequest {..} = do
+  => JWK -> LoginRequest -> m LoginResponse
+login jwk LoginRequest {..} = do
   let parsedUsername = maybeRight (makeUsername username)
   maybeAggr <- maybe (pure Nothing) UserStore.findWithCredentials parsedUsername
-  (user, creds) <- case maybeAggr of
+  (Entity userId _, creds) <- case maybeAggr of
     Nothing -> throwM Error.unauthorized
     Just (Aggregate u c) -> pure (u, c)
   when (Bcrypt.PasswordCheckFail == checkPassword password creds)
     $ throwM Error.unauthorized
-  maybeCookies <- liftIO (Sas.acceptLogin cookieSettings jwtSettings user)
-  case maybeCookies of
-    Nothing -> throwM Error.unauthorized
-    Just cookies -> pure (cookies Http.NoContent)
+  now <- liftIO getCurrentTime
+  maybeJwts <- liftIO $ sequenceTuple
+    ( signToken jwk (accessClaims userId now)
+    , signToken jwk (refreshClaims userId now)
+    )
+  case maybeJwts of
+    (Just (toString -> access), Just (toString -> refresh))
+      -> pure LoginResponse {..}
+    _ -> throwM Error.unauthorized
   where
+    sequenceTuple = uncurry (liftM2 (,))
     maybeRight = either (const Nothing) Just
     checkPassword plain Credentials {password = HashedPassword pswd} =
       Bcrypt.checkPassword (Bcrypt.mkPassword plain) (Bcrypt.PasswordHash pswd)
+    toString = LazyByteString.toString . Jwt.encodeCompact
+

--- a/src/Models/Types/Entity.hs
+++ b/src/Models/Types/Entity.hs
@@ -6,10 +6,9 @@ import Data.Aeson (FromJSON, ToJSON)
 import qualified Database.PostgreSQL.Simple.FromRow as Postgres
 import GHC.Generics (Generic)
 import Models.Types.Id (Id(..))
-import qualified Servant.Auth.Server as Sas
 
 data Entity model = Entity (Id model) model
-  deriving (Show, Eq, Generic, ToJSON, FromJSON, Sas.ToJWT, Sas.FromJWT)
+  deriving (Show, Eq, Generic, ToJSON, FromJSON)
 
 instance Postgres.FromRow model => Postgres.FromRow (Entity model) where
   fromRow :: Postgres.RowParser (Entity model)

--- a/src/Models/User.hs
+++ b/src/Models/User.hs
@@ -8,11 +8,10 @@ import Database.PostgreSQL.Simple (FromRow, ToRow)
 import GHC.Generics (Generic)
 import Models.Email (Email)
 import Models.Username (Username)
-import Servant.Auth.Server (FromJWT, ToJWT)
 
 data User = User
   { username :: !Username
   , email:: !Email
   }
   deriving stock (Show, Eq, Generic)
-  deriving anyclass (FromRow, ToRow, FromJSON, ToJSON, FromJWT, ToJWT)
+  deriving anyclass (FromRow, ToRow, FromJSON, ToJSON)

--- a/src/RequestContext.hs
+++ b/src/RequestContext.hs
@@ -1,14 +1,6 @@
-{-# LANGUAGE RecordWildCards #-}
+module RequestContext (RequestContext(..)) where
 
-module RequestContext (RequestContext(..), make) where
-
-import Models.Types.Entity (Entity(..))
 import Models.Types.Id (Id)
-import Models.User (User(..))
+import Models.User (User)
 
-newtype RequestContext = RequestContext
-  { userId :: Id User
-  }
-
-make :: Entity User -> RequestContext
-make (Entity userId _) = RequestContext {..}
+newtype RequestContext = RequestContext {userId :: Id User}

--- a/src/ThrowAll.hs
+++ b/src/ThrowAll.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- From servant-auth-server
+module ThrowAll (ThrowAll(..)) where
+
+import Servant (GenericServant, ServerError, ToServant, fromServant, (:<|>)(..))
+import Servant.Server.Generic (AsServerT)
+
+class ThrowAll a where
+  throwAll :: ServerError -> a
+
+instance (ThrowAll a, ThrowAll b) => ThrowAll (a :<|> b) where
+  throwAll :: ServerError -> a :<|> b
+  throwAll e = throwAll e :<|> throwAll e
+
+instance
+  (ThrowAll (ToServant api (AsServerT m)), GenericServant api (AsServerT m))
+  => ThrowAll (api (AsServerT m)) where
+
+  throwAll :: ServerError -> api (AsServerT m)
+  throwAll = fromServant . throwAll
+
+instance ThrowAll b => ThrowAll (a -> b) where
+  throwAll :: ServerError -> a -> b
+  throwAll e = const (throwAll e)


### PR DESCRIPTION
Moves authentication from `servant-auth-server` to generalised auth in order to gain more control over the JWT claim set (i.e. `iat`/`exp` claims) and provide more than one JWT (i.e. access token / refresh token).

There're breaking changes on login. On successful authentication the token is no longer responded using set-cookie headers but included in the response body as follows

```json
{
  "access": "aa.bb.ccc",
  "refresh": "xx.yyy.zzz"
}
```

Access tokens expire after 15 minutes and new ones can be requested using the refresh token while it's still valid (1 day, after that login credentials need to be provided again).

New tokens are requested with `POST /refresh` enpoint, an authentication header including the refresh token is expected and its response is the same as in `/login` (new access token and same refresh token).